### PR TITLE
show five popula posts

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -12,13 +12,13 @@
 					$data = json_decode($json, true);
 					foreach ( $data as $arg ) :
 						$posts = get_posts( $arg );
-						$cat_title = get_the_category( $posts[0]->ID )[0]->cat_name; 	
+						$cat_title = $arg["cat_title"]; 	
 						if( $posts ): ?>
 							<div class="new-entry"><span class="fp-category-title"><?php echo $cat_title; ?></span></div>
 							<div class="post-loop-wrap cards-section-wrapper">
 							<?php
 								foreach ( $posts as $post ) :
-									setup_postdata( $post ); 
+									setup_postdata( $post );
 							?>
 								<div class="card-wrapper">
 									<a href="<?php the_permalink(); ?>" class="card front-page-card">

--- a/resources/front_page.json
+++ b/resources/front_page.json
@@ -1,14 +1,16 @@
 {
 	"0": {
+		"meta_key" : "views",
 		"posts_per_page" : 5, 
-		"orderby" : "date",
+		"orderby" : "meta_value_num",
 		"order" : "DESC",
-		"category_name" : "experience"
+		"cat_title": "人気記事"
 	},
 	"1": {
 		"posts_per_page" : 5, 
 		"orderby" : "date",
 		"order" : "DESC",
-		"category_name" : "experience"
+		"category_name" : "experience",
+		"cat_title": "留学体験記"
 	}
 }


### PR DESCRIPTION
## Related issue
No: #20 

## What is an issue
人気記事を五件フロントページに作製

## How to solve it
以下の記事を参考
[https://manablog.org/wordpress-popular-posts-without-plugin/](url)
[https://wpdocs.osdn.jp/%E9%96%A2%E6%95%B0%E3%83%AA%E3%83%95%E3%82%A1%E3%83%AC%E3%83%B3%E3%82%B9/get_post_meta](url)

xeory_baseですでに記事のカウントをする関数が用意されている．どの関数かはわからないが確認済み．
`get_post()`渡す引数の配列に`views`を指定してやればよい

## Cnsiderable affects
フロントページ